### PR TITLE
Set ElastAlert custom resource apiVersion to v1 in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Once the `elastalert-operator` deployment in the namespace `alert` is ready, cre
 
 ```
 kubectl apply -n alert -f - <<EOF
-apiVersion: es.noah.domain/v1alpha1
+apiVersion: es.noah.domain/v1
 kind: Elastalert
 metadata:
   name: elastalert
@@ -137,7 +137,7 @@ error-message.yaml      error-status-code.yaml
 ###  2.1. <a name='ElasticsearchCert'></a>Elasticsearch Cert 
 ```
 kubectl apply -n alert -f - <<EOF
-apiVersion: es.noah.domain/v1alpha1
+apiVersion: es.noah.domain/v1
 kind: Elastalert
 metadata:
   name: elastalert
@@ -187,7 +187,7 @@ elastalert-es-cert                 Opaque                                1      
 `overall` is used to config global alert settings. If you defined `alert` in a rule, it will override `overall` settings.
 ```
 kubectl apply -n alert -f - <<EOF
-apiVersion: es.noah.domain/v1alpha1
+apiVersion: es.noah.domain/v1
 kind: Elastalert
 metadata:
   name: elastalert
@@ -216,7 +216,7 @@ EOF
 Define customized podTemplate
 ```
 kubectl apply -n alert -f - <<EOF
-apiVersion: es.noah.domain/v1alpha1
+apiVersion: es.noah.domain/v1
 kind: Elastalert
 metadata:
   name: elastalert

--- a/config/samples/es_v1alpha1_elastalert.yaml
+++ b/config/samples/es_v1alpha1_elastalert.yaml
@@ -1,4 +1,4 @@
-apiVersion: es.noah.domain/v1alpha1
+apiVersion: es.noah.domain/v1
 kind: Elastalert
 metadata:
   name: elastalert-sample


### PR DESCRIPTION
First of all thank you for this project, I think it may be very useful.
I installed the CRDs and RBAC as told in the documentation, but it seems the CRD is v1, and the CR examples are still in v1alpha1. This PR changes the CR examples.
Feel free to reject or make changes.
Cheers 🍻 